### PR TITLE
including <memory> header file

### DIFF
--- a/include/ReactiveStreams.h
+++ b/include/ReactiveStreams.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <exception>
+#include <memory>
 
 namespace reactivestreams {
 


### PR DESCRIPTION
since we are using std::shared_ptr in the interface we need to pull the header in.